### PR TITLE
Include the event's day for clarity

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,7 +54,7 @@ navigationLinks:
 
 # Hero Block
 heroTitle: "Pyjamas Conf <typeout> 2020"
-eventDate: "December 5th, 2020"
+eventDate: "Saturday, December 5th, 2020"
 typeoutTextValues: '"", "100% Online!", "Directly from your sofa!", "Totally Free!", "Worldwide!"'
 typeoutFallback: "Season"
 heroButtons:

--- a/_posts/2020-07-21-conference-launch.markdown
+++ b/_posts/2020-07-21-conference-launch.markdown
@@ -12,7 +12,7 @@ Before COVID-19 struck us all with lockdown-news, the idea to host an online con
 ---
 
 #### When is it going to happen?
-December 5th, everywhere on Earth (we will be running for 24 hours so it may be 4th or 6th for you at some time).
+Saturday, December 5th, everywhere on Earth (we will be running for 24 hours so it may be 4th or 6th for you at some time).
 
 
 #### Why PyJamas? - you may ask.


### PR DESCRIPTION
Often, if I know what day an event takes place, I can tell immediately if there's some reason I unfortunately cannot attend.

For example, some things I can't attend during workdays, others not on weekends.

Please include "Saturday" along with "December 5th, 2020" to help make scheduling clearer. It prevents needing to looking at the calendar before checking out the rest of the site.

Thank you!

# Before

![image](https://user-images.githubusercontent.com/1324225/99903795-60ded200-2ccf-11eb-813e-3c3aa8c6a63c.png)

# After

![image](https://user-images.githubusercontent.com/1324225/99903783-515f8900-2ccf-11eb-9dba-293ad2453828.png)


