### PR TITLE
Fix deprecation warning in local dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ gem install bundler
 and run next command from root folder:
 
 ```bash
-bundle install --path vendor/bundle
+bundle config set path 'vendor/bundle'
+bundle install
 ```
 
 To start Jekyll run:


### PR DESCRIPTION
# Before

```console
$ bundle install --path vendor/bundle

[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set path 'vendor/bundle'`, and stop using this flag
Fetching gem metadata from http://rubygems.org/...........
Fetching gem metadata from http://rubygems.org/.
Resolving dependencies.....
...
```

# After

```console
$ bundle config set path 'vendor/bundle'
$ bundle install
Fetching gem metadata from http://rubygems.org/...........
Fetching gem metadata from http://rubygems.org/.
Resolving dependencies....
...
```

