### PR TITLE
Include the event's day for clarity

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,7 +54,7 @@ navigationLinks:
 
 # Hero Block
 heroTitle: "Pyjamas Conf <typeout> 2021"
-eventDate: "December 4th, 2021"
+eventDate: "Saturday, December 4th, 2021"
 typeoutTextValues: '"", "Directly from your bed!", "Cannot be more lazy than that...", "Worldwide! 100% Online", "Totally Free! Just tuned in!"'
 typeoutFallback: "Season"
 heroButtons:

--- a/_posts/2021-09-04-conference-launch.markdown
+++ b/_posts/2021-09-04-conference-launch.markdown
@@ -15,7 +15,7 @@ The conference is free! There will be a 24 hours (almost non-stop) stream of you
 Last year we have lots of fun connecting 1000+ Pythonistas worldwide drinking chocolate and showing off our favourite onesies. Check out our [Twitter](https://twitter.com/intent/user?screen_name=PyjamasConf) and see.
 
 #### When is it going to happen?
-December 4th 2021, everywhere on Earth (we will be running for 24 hours, for the exact [conference starting time check here](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Pyjamas+Conf+2021&iso=20211204T07&ah=23&am=55)).
+Saturday, December 4th 2021, everywhere on Earth (we will be running for 24 hours, for the exact [conference starting time check here](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Pyjamas+Conf+2021&iso=20211204T07&ah=23&am=55)).
 
 #### CfP is now open! Become a Python speaker today!
 


### PR DESCRIPTION
Like https://github.com/pyjamasconf/pyjamas.live/pull/81 but for this year.

Often, if I know what day an event takes place, I can tell immediately if there's some reason I unfortunately cannot attend.

For example, some things I can't attend during workdays, others not on weekends.

Please include "Saturday" along with "December 4th, 2021" to help make scheduling clearer. It prevents needing to looking at the calendar before checking out the rest of the site.

Thank you!

# Before

![image](https://user-images.githubusercontent.com/1324225/138405955-0739ec03-161b-4bba-8561-e2893cefe421.png)

# After

![image](https://user-images.githubusercontent.com/1324225/138406122-e5bb5685-a198-41f1-ad3e-b186d8d3cba4.png)


